### PR TITLE
Link to settings from Plugins' list.

### DIFF
--- a/yoimages.php
+++ b/yoimages.php
@@ -36,3 +36,22 @@ require_once (YOIMG_PATH . '/vendor/sirulli/yoimages-commons/inc/init.php');
 yoimg_register_module( 'yoimages-crop', YOIMG_PATH, true );
 yoimg_register_module( 'yoimages-seo', YOIMG_PATH, true );
 yoimg_register_module( 'yoimages-search', YOIMG_PATH, true );
+
+global $wp_version;
+
+if ( version_compare( $wp_version, '2.8alpha', '>' ) )
+	add_filter( 'plugin_row_meta', 'filter_yoimg_meta', 10, 2 ); // only 2.8 and higher
+
+add_filter( 'plugin_action_links', 'filter_yoimg_meta', 10, 2 );
+
+function filter_yoimg_meta( $links, $file ) {
+	/* create link */
+	if ( $file == plugin_basename( __FILE__ ) ) {
+		array_unshift(
+			$links,
+			'<a href="options-general.php?page=yoimg-settings">'. __( 'Settings' ) .'</a>' // "Settings" is phrase from global WP's files.
+		);
+	}
+
+	return $links;
+}


### PR DESCRIPTION
Creates links like those:
![image](https://cloud.githubusercontent.com/assets/9401878/10914607/841936d8-8253-11e5-9f41-aa1544e69141.png)

There should be at least one link as it makes easier navigate when configuring plugins e.g. on fresh WP install with copied plugins.

You could edit and/or move code between files.